### PR TITLE
Fix caching causing buttons to not update properly upon navigation

### DIFF
--- a/src/comps/opportunities/OpportunityOverview.js
+++ b/src/comps/opportunities/OpportunityOverview.js
@@ -33,8 +33,8 @@ const OpportunityOverview = ({ opp, savedStatus }) => {
   const [oppSaved, setOppSaved] = React.useState(savedStatus);
   const [saveOpportunity] = useMutation(SAVE_OPP_MUTATION, {
     onCompleted() {
-      alert("Opportunity saved successfully!");
       setOppSaved(true);
+      alert("Opportunity saved successfully!");
     },
     onError(error) {
       alert(error.message);
@@ -42,8 +42,8 @@ const OpportunityOverview = ({ opp, savedStatus }) => {
   });
   const [unsaveOpportunity] = useMutation(UNSAVE_OPP_MUTATION, {
     onCompleted() {
-      alert("Opportunity unsaved successfully!");
       setOppSaved(false);
+      alert("Opportunity unsaved successfully!");
     },
     onError(error) {
       alert(error.message);

--- a/src/pages/opportunity/index.js
+++ b/src/pages/opportunity/index.js
@@ -45,6 +45,7 @@ const Opportunity = ({ match, history }) => {
   const { data, loading, error } = useQuery(QUERY, {
     variables: { signedIn: user.signedIn, id: url, userId: user.id },
     client,
+    fetchPolicy: "network-only",
   });
 
   if (!user.signedIn) return <AuthenticationRequired />;


### PR DESCRIPTION
See bug reported in #opportunities channel on Discord by @GandyT 
Turns out to be a caching issue, not touching the catalog caching but this small thing can be fixed by just exempting this one query from caching.