### PR TITLE
Patch: Use event.key not event.code

### DIFF
--- a/src/comps/home/SearchBar.js
+++ b/src/comps/home/SearchBar.js
@@ -18,7 +18,7 @@ const SearchBar = () => {
       autoFocus={true}
       onChange={(event) => setSearch(event.target.value)}
       onKeyDown={(event) => {
-        if (event.code === "Enter") navigate(`/catalog?q=${search}`);
+        if (event.key === "Enter") navigate(`/catalog?q=${search}`);
       }}
       InputProps={{
         endAdornment: (


### PR DESCRIPTION
event.key returns the string the keypress represents, but event.code returns the physical key and its code (regardless of keyboard layout), thus making it *incompatible* with mobile, or alternate enter keys like "NumpadEnter".